### PR TITLE
Fixed affiliation field on registration form

### DIFF
--- a/plugins/themes/atla-bootstrap/templates/frontend/components/registrationForm.tpl
+++ b/plugins/themes/atla-bootstrap/templates/frontend/components/registrationForm.tpl
@@ -1,0 +1,100 @@
+{**
+ * templates/frontend/components/registrationForm.tpl
+ *
+ * Copyright (c) 2014-2017 Simon Fraser University Library
+ * Copyright (c) 2003-2017 John Willinsky
+ * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
+ *
+ * @brief Display the basic registration form fields
+ *
+ * @uses $locale string Locale key to use in the affiliate field
+ * @uses $firstName string First name input entry if available
+ * @uses $middleName string Middle name input entry if available
+ * @uses $lastName string Last name input entry if available
+ * @uses $countries array List of country options
+ * @uses $country string The selected country if available
+ * @uses $email string Email input entry if available
+ * @uses $username string Username input entry if available
+ *}
+<fieldset class="identity">
+	<legend>
+		{translate key="user.profile"}
+	</legend>
+	<div class="fields">
+		<div class="form-group given_name">
+			<label>
+				{translate key="user.givenName"}
+				<span class="form-control-required">*</span>
+				<span class="sr-only">{translate key="common.required"}</span>
+				<input class="form-control" type="text" name="givenName" id="givenName" value="{$givenName|escape}" maxlength="255" required>
+			</label>
+		</div>
+		<div class="form-group family_name">
+			<label>
+				{translate key="user.familyName"}
+				<span class="form-control-required">*</span>
+				<span class="sr-only">{translate key="common.required"}</span>
+				<input class="form-control" type="text" name="familyName" id="familyName" value="{$familyName|escape}" maxlength="255" required>
+			</label>
+		</div>
+		<div class="form-group affiliation">
+			<label>
+				{translate key="user.affiliation"}
+				<span class="form-control-required">*</span>
+				<span class="sr-only">{translate key="common.required"}</span>
+				<input class="form-control" type="text" name="affiliation" id="affiliation" value="{$affiliation.$primaryLocale|escape}" required>
+			</label>
+		</div>
+		<div class="form-group country">
+			<label>
+				{translate key="common.country"}
+				<span class="form-control-required">*</span>
+				<span class="sr-only">{translate key="common.required"}</span>
+				<select class="form-control" name="country" id="country" required>
+					<option></option>
+					{html_options options=$countries selected=$country}
+				</select>
+			</label>
+		</div>
+	</div>
+</fieldset>
+
+<fieldset class="login">
+	<legend>
+		{translate key="user.login"}
+	</legend>
+	<div class="fields">
+		<div class="form-group email">
+			<label>
+				{translate key="user.email"}
+				<span class="form-control-required">*</span>
+				<span class="sr-only">{translate key="common.required"}</span>
+				<input class="form-control" type="email" name="email" id="email" value="{$email|escape}" maxlength="90" required>
+			</label>
+		</div>
+		<div class="form-group username">
+			<label>
+				{translate key="user.username"}
+				<span class="form-control-required">*</span>
+				<span class="sr-only">{translate key="common.required"}</span>
+				<input class="form-control" type="text" name="username" id="username" value="{$username|escape}" maxlength="32" required>
+			</label>
+		</div>
+		<div class="form-group password">
+			<label>
+				{translate key="user.password"}
+				<span class="form-control-required">*</span>
+				<span class="sr-only">{translate key="common.required"}</span>
+				<input class="form-control" type="password" name="password" id="password" password="true" maxlength="32" required>
+			</label>
+		</div>
+		<div class="form-group password">
+			<label>
+				{translate key="user.repeatPassword"}
+				<span class="form-control-required">*</span>
+				<span class="sr-only">{translate key="common.required"}</span>
+				<input class="form-control" type="password" name="password2" id="password2" password="true" maxlength="32" required>
+			</label>
+		</div>
+	</div>
+</fieldset>

--- a/plugins/themes/atla-bootstrap/templates/user/contactForm.tpl
+++ b/plugins/themes/atla-bootstrap/templates/user/contactForm.tpl
@@ -1,0 +1,57 @@
+{**
+ * templates/user/contactForm.tpl
+ *
+ * Copyright (c) 2014-2021 Simon Fraser University
+ * Copyright (c) 2003-2021 John Willinsky
+ * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
+ *
+ * User profile form.
+ *}
+<script>
+	$(function() {ldelim}
+		// Attach the form handler.
+		$('#contactForm').pkpHandler('$.pkp.controllers.form.AjaxFormHandler');
+	{rdelim});
+</script>
+
+<form class="pkp_form" id="contactForm" method="post" action="{url op="saveContact"}">
+	{* Help Link *}
+	{help file="user-profile" class="pkp_help_tab"}
+
+	{csrf}
+
+	{include file="controllers/notification/inPlaceNotification.tpl" notificationId="contactFormNotification"}
+
+	{fbvFormSection}
+		{fbvElement type="email" label="user.email" id="email" value=$email size=$fbvStyles.size.MEDIUM required=true}
+		{fbvElement type="textarea" label="user.signature" multilingual="true" name="signature" id="signature" value=$signature rich=true size=$fbvStyles.size.MEDIUM}
+		{fbvElement type="tel" label="user.phone" name="phone" id="phone" value=$phone maxlength="24" size=$fbvStyles.size.SMALL}
+		{fbvElement type="text" label="user.affiliation" multilingual="true" name="affiliation" id="affiliation" value=$affiliation size=$fbvStyles.size.MEDIUM required=true}
+	{/fbvFormSection}
+	{fbvFormSection}
+		{fbvElement type="textarea" label="common.mailingAddress" name="mailingAddress" id="mailingAddress" rich=true value=$mailingAddress size=$fbvStyles.size.MEDIUM}
+		{fbvElement type="select" label="common.country" name="country" id="country" required=true defaultLabel="" defaultValue="" from=$countries selected=$country translate=false size=$fbvStyles.size.MEDIUM}
+	{/fbvFormSection}
+
+	{if count($availableLocales) > 1}
+		{fbvFormSection title="user.workingLanguages" list=true}
+			{foreach from=$availableLocales key=localeKey item=localeName}
+				{if $userLocales && in_array($localeKey, $userLocales)}
+					{assign var="checked" value=true}
+				{else}
+					{assign var="checked" value=false}
+				{/if}
+				{fbvElement type="checkbox" name="userLocales[]" id="userLocales-$localeKey" value=$localeKey checked=$checked label=$localeName|escape translate=false}
+			{/foreach}
+		{/fbvFormSection}
+	{/if}
+
+	<p>
+		{capture assign="privacyUrl"}{url router=$smarty.const.ROUTE_PAGE page="about" op="privacy"}{/capture}
+		{translate key="user.privacyLink" privacyUrl=$privacyUrl}
+	</p>
+
+	<p><span class="formRequired">{translate key="common.requiredField"}</span></p>
+
+	{fbvFormButtons hideCancel=true submitText="common.save"}
+</form>

--- a/plugins/themes/atla-other-bootstrap/templates/frontend/components/registrationForm.tpl
+++ b/plugins/themes/atla-other-bootstrap/templates/frontend/components/registrationForm.tpl
@@ -1,0 +1,100 @@
+{**
+ * templates/frontend/components/registrationForm.tpl
+ *
+ * Copyright (c) 2014-2017 Simon Fraser University Library
+ * Copyright (c) 2003-2017 John Willinsky
+ * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
+ *
+ * @brief Display the basic registration form fields
+ *
+ * @uses $locale string Locale key to use in the affiliate field
+ * @uses $firstName string First name input entry if available
+ * @uses $middleName string Middle name input entry if available
+ * @uses $lastName string Last name input entry if available
+ * @uses $countries array List of country options
+ * @uses $country string The selected country if available
+ * @uses $email string Email input entry if available
+ * @uses $username string Username input entry if available
+ *}
+<fieldset class="identity">
+	<legend>
+		{translate key="user.profile"}
+	</legend>
+	<div class="fields">
+		<div class="form-group given_name">
+			<label>
+				{translate key="user.givenName"}
+				<span class="form-control-required">*</span>
+				<span class="sr-only">{translate key="common.required"}</span>
+				<input class="form-control" type="text" name="givenName" id="givenName" value="{$givenName|escape}" maxlength="255" required>
+			</label>
+		</div>
+		<div class="form-group family_name">
+			<label>
+				{translate key="user.familyName"}
+				<span class="form-control-required">*</span>
+				<span class="sr-only">{translate key="common.required"}</span>
+				<input class="form-control" type="text" name="familyName" id="familyName" value="{$familyName|escape}" maxlength="255" required>
+			</label>
+		</div>
+		<div class="form-group affiliation">
+			<label>
+				{translate key="user.affiliation"}
+				<span class="form-control-required">*</span>
+				<span class="sr-only">{translate key="common.required"}</span>
+				<input class="form-control" type="text" name="affiliation" id="affiliation" value="{$affiliation.$primaryLocale|escape}" required>
+			</label>
+		</div>
+		<div class="form-group country">
+			<label>
+				{translate key="common.country"}
+				<span class="form-control-required">*</span>
+				<span class="sr-only">{translate key="common.required"}</span>
+				<select class="form-control" name="country" id="country" required>
+					<option></option>
+					{html_options options=$countries selected=$country}
+				</select>
+			</label>
+		</div>
+	</div>
+</fieldset>
+
+<fieldset class="login">
+	<legend>
+		{translate key="user.login"}
+	</legend>
+	<div class="fields">
+		<div class="form-group email">
+			<label>
+				{translate key="user.email"}
+				<span class="form-control-required">*</span>
+				<span class="sr-only">{translate key="common.required"}</span>
+				<input class="form-control" type="email" name="email" id="email" value="{$email|escape}" maxlength="90" required>
+			</label>
+		</div>
+		<div class="form-group username">
+			<label>
+				{translate key="user.username"}
+				<span class="form-control-required">*</span>
+				<span class="sr-only">{translate key="common.required"}</span>
+				<input class="form-control" type="text" name="username" id="username" value="{$username|escape}" maxlength="32" required>
+			</label>
+		</div>
+		<div class="form-group password">
+			<label>
+				{translate key="user.password"}
+				<span class="form-control-required">*</span>
+				<span class="sr-only">{translate key="common.required"}</span>
+				<input class="form-control" type="password" name="password" id="password" password="true" maxlength="32" required>
+			</label>
+		</div>
+		<div class="form-group password">
+			<label>
+				{translate key="user.repeatPassword"}
+				<span class="form-control-required">*</span>
+				<span class="sr-only">{translate key="common.required"}</span>
+				<input class="form-control" type="password" name="password2" id="password2" password="true" maxlength="32" required>
+			</label>
+		</div>
+	</div>
+</fieldset>

--- a/plugins/themes/atla-other-bootstrap/templates/user/contactForm.tpl
+++ b/plugins/themes/atla-other-bootstrap/templates/user/contactForm.tpl
@@ -1,0 +1,57 @@
+{**
+ * templates/user/contactForm.tpl
+ *
+ * Copyright (c) 2014-2021 Simon Fraser University
+ * Copyright (c) 2003-2021 John Willinsky
+ * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
+ *
+ * User profile form.
+ *}
+<script>
+	$(function() {ldelim}
+		// Attach the form handler.
+		$('#contactForm').pkpHandler('$.pkp.controllers.form.AjaxFormHandler');
+	{rdelim});
+</script>
+
+<form class="pkp_form" id="contactForm" method="post" action="{url op="saveContact"}">
+	{* Help Link *}
+	{help file="user-profile" class="pkp_help_tab"}
+
+	{csrf}
+
+	{include file="controllers/notification/inPlaceNotification.tpl" notificationId="contactFormNotification"}
+
+	{fbvFormSection}
+		{fbvElement type="email" label="user.email" id="email" value=$email size=$fbvStyles.size.MEDIUM required=true}
+		{fbvElement type="textarea" label="user.signature" multilingual="true" name="signature" id="signature" value=$signature rich=true size=$fbvStyles.size.MEDIUM}
+		{fbvElement type="tel" label="user.phone" name="phone" id="phone" value=$phone maxlength="24" size=$fbvStyles.size.SMALL}
+		{fbvElement type="text" label="user.affiliation" multilingual="true" name="affiliation" id="affiliation" value=$affiliation size=$fbvStyles.size.MEDIUM required=true}
+	{/fbvFormSection}
+	{fbvFormSection}
+		{fbvElement type="textarea" label="common.mailingAddress" name="mailingAddress" id="mailingAddress" rich=true value=$mailingAddress size=$fbvStyles.size.MEDIUM}
+		{fbvElement type="select" label="common.country" name="country" id="country" required=true defaultLabel="" defaultValue="" from=$countries selected=$country translate=false size=$fbvStyles.size.MEDIUM}
+	{/fbvFormSection}
+
+	{if count($availableLocales) > 1}
+		{fbvFormSection title="user.workingLanguages" list=true}
+			{foreach from=$availableLocales key=localeKey item=localeName}
+				{if $userLocales && in_array($localeKey, $userLocales)}
+					{assign var="checked" value=true}
+				{else}
+					{assign var="checked" value=false}
+				{/if}
+				{fbvElement type="checkbox" name="userLocales[]" id="userLocales-$localeKey" value=$localeKey checked=$checked label=$localeName|escape translate=false}
+			{/foreach}
+		{/fbvFormSection}
+	{/if}
+
+	<p>
+		{capture assign="privacyUrl"}{url router=$smarty.const.ROUTE_PAGE page="about" op="privacy"}{/capture}
+		{translate key="user.privacyLink" privacyUrl=$privacyUrl}
+	</p>
+
+	<p><span class="formRequired">{translate key="common.requiredField"}</span></p>
+
+	{fbvFormButtons hideCancel=true submitText="common.save"}
+</form>

--- a/plugins/themes/atla-tl-bootstrap/templates/frontend/components/registrationForm.tpl
+++ b/plugins/themes/atla-tl-bootstrap/templates/frontend/components/registrationForm.tpl
@@ -1,0 +1,100 @@
+{**
+ * templates/frontend/components/registrationForm.tpl
+ *
+ * Copyright (c) 2014-2017 Simon Fraser University Library
+ * Copyright (c) 2003-2017 John Willinsky
+ * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
+ *
+ * @brief Display the basic registration form fields
+ *
+ * @uses $locale string Locale key to use in the affiliate field
+ * @uses $firstName string First name input entry if available
+ * @uses $middleName string Middle name input entry if available
+ * @uses $lastName string Last name input entry if available
+ * @uses $countries array List of country options
+ * @uses $country string The selected country if available
+ * @uses $email string Email input entry if available
+ * @uses $username string Username input entry if available
+ *}
+<fieldset class="identity">
+	<legend>
+		{translate key="user.profile"}
+	</legend>
+	<div class="fields">
+		<div class="form-group given_name">
+			<label>
+				{translate key="user.givenName"}
+				<span class="form-control-required">*</span>
+				<span class="sr-only">{translate key="common.required"}</span>
+				<input class="form-control" type="text" name="givenName" id="givenName" value="{$givenName|escape}" maxlength="255" required>
+			</label>
+		</div>
+		<div class="form-group family_name">
+			<label>
+				{translate key="user.familyName"}
+				<span class="form-control-required">*</span>
+				<span class="sr-only">{translate key="common.required"}</span>
+				<input class="form-control" type="text" name="familyName" id="familyName" value="{$familyName|escape}" maxlength="255" required>
+			</label>
+		</div>
+		<div class="form-group affiliation">
+			<label>
+				{translate key="user.affiliation"}
+				<span class="form-control-required">*</span>
+				<span class="sr-only">{translate key="common.required"}</span>
+				<input class="form-control" type="text" name="affiliation" id="affiliation" value="{$affiliation.$primaryLocale|escape}" required>
+			</label>
+		</div>
+		<div class="form-group country">
+			<label>
+				{translate key="common.country"}
+				<span class="form-control-required">*</span>
+				<span class="sr-only">{translate key="common.required"}</span>
+				<select class="form-control" name="country" id="country" required>
+					<option></option>
+					{html_options options=$countries selected=$country}
+				</select>
+			</label>
+		</div>
+	</div>
+</fieldset>
+
+<fieldset class="login">
+	<legend>
+		{translate key="user.login"}
+	</legend>
+	<div class="fields">
+		<div class="form-group email">
+			<label>
+				{translate key="user.email"}
+				<span class="form-control-required">*</span>
+				<span class="sr-only">{translate key="common.required"}</span>
+				<input class="form-control" type="email" name="email" id="email" value="{$email|escape}" maxlength="90" required>
+			</label>
+		</div>
+		<div class="form-group username">
+			<label>
+				{translate key="user.username"}
+				<span class="form-control-required">*</span>
+				<span class="sr-only">{translate key="common.required"}</span>
+				<input class="form-control" type="text" name="username" id="username" value="{$username|escape}" maxlength="32" required>
+			</label>
+		</div>
+		<div class="form-group password">
+			<label>
+				{translate key="user.password"}
+				<span class="form-control-required">*</span>
+				<span class="sr-only">{translate key="common.required"}</span>
+				<input class="form-control" type="password" name="password" id="password" password="true" maxlength="32" required>
+			</label>
+		</div>
+		<div class="form-group password">
+			<label>
+				{translate key="user.repeatPassword"}
+				<span class="form-control-required">*</span>
+				<span class="sr-only">{translate key="common.required"}</span>
+				<input class="form-control" type="password" name="password2" id="password2" password="true" maxlength="32" required>
+			</label>
+		</div>
+	</div>
+</fieldset>

--- a/plugins/themes/atla-tl-bootstrap/templates/user/contactForm.tpl
+++ b/plugins/themes/atla-tl-bootstrap/templates/user/contactForm.tpl
@@ -1,0 +1,57 @@
+{**
+ * templates/user/contactForm.tpl
+ *
+ * Copyright (c) 2014-2021 Simon Fraser University
+ * Copyright (c) 2003-2021 John Willinsky
+ * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
+ *
+ * User profile form.
+ *}
+<script>
+	$(function() {ldelim}
+		// Attach the form handler.
+		$('#contactForm').pkpHandler('$.pkp.controllers.form.AjaxFormHandler');
+	{rdelim});
+</script>
+
+<form class="pkp_form" id="contactForm" method="post" action="{url op="saveContact"}">
+	{* Help Link *}
+	{help file="user-profile" class="pkp_help_tab"}
+
+	{csrf}
+
+	{include file="controllers/notification/inPlaceNotification.tpl" notificationId="contactFormNotification"}
+
+	{fbvFormSection}
+		{fbvElement type="email" label="user.email" id="email" value=$email size=$fbvStyles.size.MEDIUM required=true}
+		{fbvElement type="textarea" label="user.signature" multilingual="true" name="signature" id="signature" value=$signature rich=true size=$fbvStyles.size.MEDIUM}
+		{fbvElement type="tel" label="user.phone" name="phone" id="phone" value=$phone maxlength="24" size=$fbvStyles.size.SMALL}
+		{fbvElement type="text" label="user.affiliation" multilingual="true" name="affiliation" id="affiliation" value=$affiliation size=$fbvStyles.size.MEDIUM required=true}
+	{/fbvFormSection}
+	{fbvFormSection}
+		{fbvElement type="textarea" label="common.mailingAddress" name="mailingAddress" id="mailingAddress" rich=true value=$mailingAddress size=$fbvStyles.size.MEDIUM}
+		{fbvElement type="select" label="common.country" name="country" id="country" required=true defaultLabel="" defaultValue="" from=$countries selected=$country translate=false size=$fbvStyles.size.MEDIUM}
+	{/fbvFormSection}
+
+	{if count($availableLocales) > 1}
+		{fbvFormSection title="user.workingLanguages" list=true}
+			{foreach from=$availableLocales key=localeKey item=localeName}
+				{if $userLocales && in_array($localeKey, $userLocales)}
+					{assign var="checked" value=true}
+				{else}
+					{assign var="checked" value=false}
+				{/if}
+				{fbvElement type="checkbox" name="userLocales[]" id="userLocales-$localeKey" value=$localeKey checked=$checked label=$localeName|escape translate=false}
+			{/foreach}
+		{/fbvFormSection}
+	{/if}
+
+	<p>
+		{capture assign="privacyUrl"}{url router=$smarty.const.ROUTE_PAGE page="about" op="privacy"}{/capture}
+		{translate key="user.privacyLink" privacyUrl=$privacyUrl}
+	</p>
+
+	<p><span class="formRequired">{translate key="common.requiredField"}</span></p>
+
+	{fbvFormButtons hideCancel=true submitText="common.save"}
+</form>


### PR DESCRIPTION
Fixes problems with affiliation field on registration form. Text is now being stored as string not serialized JSON.

To test:
* Go into any journal's home page that allows open registration.
* Register an account.
* Sign into the account.
* Go to the user profile section and the contact tab. Verify that the affiliation is being displayed correctly.